### PR TITLE
Moves manual.translate configuration to the production block

### DIFF
--- a/configs/module.ini
+++ b/configs/module.ini
@@ -7,14 +7,13 @@
 ;resources.view.helperPath.Manual_View_Helper = '/var/www/tiger-www/application/modules/manual/views/helpers/'
 ;resources.view.helperPath.Manual_View_Helper = "Manual/View/Helper"
 ;resources.view.helperPathPrefix.Manual_View_Helper = "Manual_View_Helper"
-
-
-[staging : production]
 manual.translate.default_language = 'en'
 manual.translate.languages[] = 'en'
 manual.translate.languages[] = 'es'
 manual.translate.languages[] = 'fr'
 manual.translate.languages[] = 'pt'
+
+[staging : production]
 
 [testing : production]
 


### PR DESCRIPTION
Moves manual.translate configuration from the staging block to the production block.

Unsupported languages are still throwing errors on https://zf1future.com/manual . Looking through the code, I noticed that I had initially added the configuration to the wrong section. I do not think that this will solve the problem, it looks like maybe the latest code it not deployed; I would expect it to fail in a different way.